### PR TITLE
Feature/account controller - Register and delete endpoint and more

### DIFF
--- a/src/main/java/org/example/marketplacebackend/DTO/incoming/UserDTO.java
+++ b/src/main/java/org/example/marketplacebackend/DTO/incoming/UserDTO.java
@@ -4,6 +4,7 @@ import java.sql.Date;
 
 /**
  * DTO used for sending user registration form data.
+ *
  * @param firstName
  * @param lastName
  * @param email
@@ -11,6 +12,7 @@ import java.sql.Date;
  * @param password
  * @param date_of_birth
  */
-public record UserDTO (String firstName, String lastName, String email, String username, String password, Date date_of_birth){
+public record UserDTO(String firstName, String lastName, String email, String username,
+                      String password, Date date_of_birth) {
 
 }

--- a/src/main/java/org/example/marketplacebackend/DTO/incoming/UserDTO.java
+++ b/src/main/java/org/example/marketplacebackend/DTO/incoming/UserDTO.java
@@ -1,0 +1,16 @@
+package org.example.marketplacebackend.DTO.incoming;
+
+import java.sql.Date;
+
+/**
+ * DTO used for sending user registration form data.
+ * @param firstName
+ * @param lastName
+ * @param email
+ * @param username
+ * @param password
+ * @param date_of_birth
+ */
+public record UserDTO (String firstName, String lastName, String email, String username, String password, Date date_of_birth){
+
+}

--- a/src/main/java/org/example/marketplacebackend/DTO/outgoing/UserRegisteredResponseDTO.java
+++ b/src/main/java/org/example/marketplacebackend/DTO/outgoing/UserRegisteredResponseDTO.java
@@ -1,0 +1,13 @@
+package org.example.marketplacebackend.DTO.outgoing;
+
+import java.sql.Date;
+
+/**
+ * DTO used for sending a response when a user is registered.
+ * @param firstName
+ * @param lastName
+ * @param email
+ * @param username
+ * @param date_of_birth
+ */
+public record UserRegisteredResponseDTO (String firstName, String lastName, String email, String username, Date date_of_birth) { }

--- a/src/main/java/org/example/marketplacebackend/config/SecurityConfig.java
+++ b/src/main/java/org/example/marketplacebackend/config/SecurityConfig.java
@@ -38,7 +38,10 @@ public class SecurityConfig {
         )
         .permitAll()
         //require auth to access these endpoints
-        .requestMatchers("/auth-required")
+        .requestMatchers(
+            "/auth-required",
+            "/v1/accounts"
+        )
         .hasRole("USER")
     );
 

--- a/src/main/java/org/example/marketplacebackend/config/SecurityConfig.java
+++ b/src/main/java/org/example/marketplacebackend/config/SecurityConfig.java
@@ -33,7 +33,8 @@ public class SecurityConfig {
         .requestMatchers(
             "/auth-not-required",
             "/v1/accounts/login",
-            "/login"
+            "/login",
+            "/v1/accounts/register"
         )
         .permitAll()
         //require auth to access these endpoints
@@ -65,7 +66,7 @@ public class SecurityConfig {
     return new WebMvcConfigurer() {
       @Override
       public void addCorsMappings(@NonNull CorsRegistry registry) {
-        registry.addMapping("/**").allowedOrigins("http://localhost:80, http://localhost:808, http://127.0.0.1:8080, http://localhost:3000")
+        registry.addMapping("/**").allowedOrigins("http://localhost:80, http://localhost:8080, http://127.0.0.1:8080, http://localhost:3000")
             .allowCredentials(true);
       }
     };

--- a/src/main/java/org/example/marketplacebackend/controller/AccountsController.java
+++ b/src/main/java/org/example/marketplacebackend/controller/AccountsController.java
@@ -1,33 +1,60 @@
 package org.example.marketplacebackend.controller;
 
-import jakarta.servlet.http.HttpServletRequest;
-import org.example.marketplacebackend.DTO.incoming.UserDTO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.example.marketplacebackend.model.Account;
-import org.example.marketplacebackend.repository.AccountRepository;
 import org.example.marketplacebackend.service.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
-import java.util.Collections;
-import java.util.Map;
+import java.util.UUID;
 
 @RequestMapping("v1/accounts")
 @CrossOrigin(origins = "localhost:3000", allowCredentials = "true")
 @RestController
 public class AccountsController {
+
   private final UserService userService;
+  private final PasswordEncoder passwordEncoder;
 
-  public AccountsController(UserService userService) {
+  public AccountsController(UserService userService, PasswordEncoder passwordEncoder) {
     this.userService = userService;
-
+    this.passwordEncoder = passwordEncoder;
   }
 
-  @PostMapping ( "/register")
-  public ResponseEntity<String> register(@RequestBody Account user, HttpServletRequest httpServletRequest) {
+  @PostMapping("/register")
+  public ResponseEntity<String> register(@RequestBody Account user) {
+    String password = user.getPassword();
+    String encodedPassword = passwordEncoder.encode(password);
+    user.setPassword(encodedPassword);
+
     userService.saveUser(user);
-    return ResponseEntity.ok().body("Success");
+
+    Account retrieveUser = userService.getAccountOrException(user.getId());
+    ObjectMapper objectMapper = new ObjectMapper();
+    String userJson;
+
+    try {
+      userJson = objectMapper.writeValueAsString(retrieveUser);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+    return ResponseEntity.status(HttpStatus.CREATED).body(userJson);
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<String> deleteUser(@PathVariable UUID id) {
+    try {
+      Account account = userService.getAccountOrException(id);
+      userService.deleteUser(account);
+
+      return ResponseEntity.status(HttpStatus.OK).body("Deleted successfully");
+    } catch (UsernameNotFoundException e) {
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("User not found");
+    }
   }
 
 }

--- a/src/main/java/org/example/marketplacebackend/controller/AccountsController.java
+++ b/src/main/java/org/example/marketplacebackend/controller/AccountsController.java
@@ -1,24 +1,33 @@
 package org.example.marketplacebackend.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import org.example.marketplacebackend.DTO.incoming.UserDTO;
+import org.example.marketplacebackend.model.Account;
 import org.example.marketplacebackend.repository.AccountRepository;
+import org.example.marketplacebackend.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import java.util.Collections;
 import java.util.Map;
 
-@RequestMapping("v1/account")
+@RequestMapping("v1/accounts")
 @CrossOrigin(origins = "localhost:3000", allowCredentials = "true")
-@Controller
+@RestController
 public class AccountsController {
-  private final AccountRepository accountRepository;
+  private final UserService userService;
 
-  public AccountsController (AccountRepository accountRepository) {
-    this.accountRepository = accountRepository;
+  public AccountsController(UserService userService) {
+    this.userService = userService;
+
   }
 
-  @GetMapping("/test")
-  public Map<String, Object> greeting() {
-    return Collections.singletonMap("message", "Hello, World");
+  @PostMapping ( "/register")
+  public ResponseEntity<String> register(@RequestBody Account user, HttpServletRequest httpServletRequest) {
+    userService.saveUser(user);
+    return ResponseEntity.ok().body("Success");
   }
 
 }

--- a/src/main/java/org/example/marketplacebackend/controller/AccountsController.java
+++ b/src/main/java/org/example/marketplacebackend/controller/AccountsController.java
@@ -1,5 +1,24 @@
 package org.example.marketplacebackend.controller;
 
+import org.example.marketplacebackend.repository.AccountRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import java.util.Collections;
+import java.util.Map;
+
+@RequestMapping("v1/account")
+@CrossOrigin(origins = "localhost:3000", allowCredentials = "true")
+@Controller
 public class AccountsController {
+  private final AccountRepository accountRepository;
+
+  public AccountsController (AccountRepository accountRepository) {
+    this.accountRepository = accountRepository;
+  }
+
+  @GetMapping("/test")
+  public Map<String, Object> greeting() {
+    return Collections.singletonMap("message", "Hello, World");
+  }
 
 }

--- a/src/main/java/org/example/marketplacebackend/repository/AccountRepository.java
+++ b/src/main/java/org/example/marketplacebackend/repository/AccountRepository.java
@@ -10,4 +10,6 @@ public interface AccountRepository extends JpaRepository<Account, UUID> {
   Optional<Account> findByUsername(String username);
 
   Optional<Account> findById(UUID id);
+
+  void deleteByUsername(String username);
 }

--- a/src/main/java/org/example/marketplacebackend/service/UserService.java
+++ b/src/main/java/org/example/marketplacebackend/service/UserService.java
@@ -105,6 +105,7 @@ public class UserService {
 
   /**
    * Deletes the given to user to the database.
+   *
    * @param targetUser The user to be deleted.
    */
   public void deleteUser(Account targetUser) {

--- a/src/main/java/org/example/marketplacebackend/service/UserService.java
+++ b/src/main/java/org/example/marketplacebackend/service/UserService.java
@@ -102,4 +102,12 @@ public class UserService {
   public Account saveUser(Account targetUser) {
     return accountRepo.save(targetUser);
   }
+
+  /**
+   * Deletes the given to user to the database.
+   * @param targetUser The user to be deleted.
+   */
+  public void deleteUser(Account targetUser) {
+    accountRepo.delete(targetUser);
+  }
 }

--- a/src/test/java/org/example/marketplacebackend/MarketplaceBackendApplicationTests.java
+++ b/src/test/java/org/example/marketplacebackend/MarketplaceBackendApplicationTests.java
@@ -40,7 +40,7 @@ class MarketplaceBackendApplicationTests {
     seller.setFirst_name("Test");
     seller.setLast_name("Seller");
     seller.setDate_of_birth(new Date(1993-03-11));
-    seller.setEmail("test@mail.com");
+    seller.setEmail("seller@mail.com");
     seller.setPassword("test123");
     seller.setUsername("ffsFILIP");
 

--- a/src/test/java/org/example/marketplacebackend/MarketplaceBackendApplicationTests.java
+++ b/src/test/java/org/example/marketplacebackend/MarketplaceBackendApplicationTests.java
@@ -12,8 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import java.sql.Date;
-import java.util.ArrayList;
-import java.util.List;
 
 @SpringBootTest
 class MarketplaceBackendApplicationTests {

--- a/src/test/java/org/example/marketplacebackend/TestAccountEndpoints.java
+++ b/src/test/java/org/example/marketplacebackend/TestAccountEndpoints.java
@@ -1,0 +1,54 @@
+package org.example.marketplacebackend;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.marketplacebackend.model.Account;
+import org.example.marketplacebackend.repository.AccountRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.sql.Date;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class TestAccountEndpoints {
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  void testRegisterUser() throws Exception {
+    Account account = new Account();
+    account.setUsername("test");
+    account.setEmail("test@mail.com");
+    account.setPassword("test123");
+    account.setFirst_name("test1");
+    account.setLast_name("testsson");
+    account.setDate_of_birth(Date.valueOf("1993-03-11"));
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    String json = objectMapper.writeValueAsString(account);
+
+    ResultActions createUser = mockMvc.perform(post("/v1/accounts/register")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(json));
+
+    createUser.andExpect(status().isCreated());
+
+    // NOTE: Does not work yet because of security configurations
+    // String response = createUser.andReturn().getResponse().getContentAsString();
+    // JsonNode rootNode = objectMapper.readTree(response);
+    // String id = rootNode.get("id").toString();
+    // ResultActions deleteUser = mockMvc.perform(delete("/v1/accounts/" + id)
+    //     .contentType(MediaType.APPLICATION_JSON));
+
+    // deleteUser.andExpect(status().isOk());
+  }
+}


### PR DESCRIPTION
What has been made in this PR:

Note: If you're testing the testRegisterUser method do not forget to delete the user in the DB afterwards.

1. /register endpoint for account creation
2. add /v1/accounts/register as requestMatchers in SecurityConfig.java
3. /{id} endpoint for deletion (can not be tested at the moment because of security configurations)
4. add method deleteUser in UserService.java
5. Succesful test cases for /register (unfortunately needs manual deletion of the account created at the moment)