### PR TITLE
Add missing ROLE_ prefix in the MarketplaceUserPrincipal class

### DIFF
--- a/src/main/java/org/example/marketplacebackend/model/MarketplaceUserPrincipal.java
+++ b/src/main/java/org/example/marketplacebackend/model/MarketplaceUserPrincipal.java
@@ -40,10 +40,7 @@ public class MarketplaceUserPrincipal implements UserDetails {
    */
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
-    SimpleGrantedAuthority authority = new SimpleGrantedAuthority("USER");
-    List<GrantedAuthority> authorities = new ArrayList<>();
-    authorities.add(authority);
-    return authorities;
+    return List.of(new SimpleGrantedAuthority("ROLE_USER"));
   }
 
   /**


### PR DESCRIPTION
The "USER" role in MarketplaceUserPrincipal wasn't prefixed with the required "ROLE_" prefix, which Spring requires. As such, all endpoints requiring the role "USER" were incorrectly returning HTTP unauthorized, even if the user was authenticated. 