### PR TITLE
Configure authentication setup for frontend usage

### DIFF
--- a/src/main/java/org/example/marketplacebackend/config/LoginFailureHandlerImpl.java
+++ b/src/main/java/org/example/marketplacebackend/config/LoginFailureHandlerImpl.java
@@ -1,0 +1,22 @@
+package org.example.marketplacebackend.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+/**
+ * This class is used to override the default behavior of Spring Security's login failure handler.
+ * This implementation returns HTTP 401 on unsuccessful logins instead of issuing a redirect to the
+ * default login page.
+ */
+public class LoginFailureHandlerImpl implements AuthenticationFailureHandler {
+
+  @Override
+  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException exception) throws IOException, ServletException {
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+  }
+}

--- a/src/main/java/org/example/marketplacebackend/config/LoginSuccessHandlerImpl.java
+++ b/src/main/java/org/example/marketplacebackend/config/LoginSuccessHandlerImpl.java
@@ -1,0 +1,18 @@
+package org.example.marketplacebackend.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+/**
+ * This class is used to override the default behavior of Spring Security's login success handler.
+ * This implementation returns HTTP 200 on successful logins instead of issuing a redirect.
+ */
+public class LoginSuccessHandlerImpl implements AuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+}

--- a/src/main/java/org/example/marketplacebackend/config/LogoutSuccessHandlerImpl.java
+++ b/src/main/java/org/example/marketplacebackend/config/LogoutSuccessHandlerImpl.java
@@ -1,0 +1,21 @@
+package org.example.marketplacebackend.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+
+/**
+ * This class is used to override the default behavior of Spring Security's logout success handler.
+ * This implementation returns HTTP 200 on successful logout instead of issuing a redirect.
+ */
+public class LogoutSuccessHandlerImpl implements LogoutSuccessHandler {
+
+  @Override
+  public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
+      Authentication authentication) throws IOException, ServletException {
+    response.setStatus(HttpServletResponse.SC_OK);
+  }
+}

--- a/src/main/java/org/example/marketplacebackend/config/SecurityConfig.java
+++ b/src/main/java/org/example/marketplacebackend/config/SecurityConfig.java
@@ -4,17 +4,20 @@ import lombok.NonNull;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-//@EnableWebSecurity
+@EnableWebSecurity
 //@EnableMethodSecurity
 public class SecurityConfig {
 
@@ -31,9 +34,8 @@ public class SecurityConfig {
         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
         //don't require auth for these endpoints
         .requestMatchers(
-            "/auth-not-required",
             "/v1/accounts/login",
-            "/login",
+            "/v1/accounts/logout",
             "/v1/accounts/register",
             "/images/**",
             "/v1/categories",
@@ -43,22 +45,27 @@ public class SecurityConfig {
         .permitAll()
         //require auth to access these endpoints
         .requestMatchers(
-            "/auth-required",
-            "/v1/accounts"
+            "/v1/accounts",
+            "/v1/tests/username"
         )
         .hasRole("USER")
     );
 
     http.formLogin(loginForm -> loginForm
-            .loginProcessingUrl("/v1/accounts/login"))
+            .loginProcessingUrl("/v1/accounts/login")
+            .successHandler(new LoginSuccessHandlerImpl())
+            .failureHandler(new LoginFailureHandlerImpl())
+        )
         .logout(logoutConfigurer -> logoutConfigurer
+            .logoutUrl("/v1/accounts/logout")
+            .logoutSuccessHandler(new LogoutSuccessHandlerImpl())
             .deleteCookies("JSESSIONID")
         );
 
-    /* TODO: add this code after adding a login page in frontend
-        http.exceptionHandling(exceptionHandling -> exceptionHandling
+    // return HTTP 401 when a user tries to access an endpoint that they don't have access to,
+    // instead of trying to redirect them to the default login page
+    http.exceptionHandling(exceptionHandling -> exceptionHandling
         .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)));
-     */
 
     return http.build();
   }
@@ -73,7 +80,7 @@ public class SecurityConfig {
     return new WebMvcConfigurer() {
       @Override
       public void addCorsMappings(@NonNull CorsRegistry registry) {
-        registry.addMapping("/**").allowedOrigins("http://localhost:80, http://localhost:8080, http://127.0.0.1:8080, http://localhost:3000")
+        registry.addMapping("/**").allowedOrigins("http://localhost:3000", "https://marketplace.johros.dev")
             .allowCredentials(true);
       }
     };

--- a/src/main/java/org/example/marketplacebackend/controller/TestingController.java
+++ b/src/main/java/org/example/marketplacebackend/controller/TestingController.java
@@ -1,0 +1,36 @@
+package org.example.marketplacebackend.controller;
+
+import java.security.Principal;
+import org.example.marketplacebackend.model.Account;
+import org.example.marketplacebackend.service.UserService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/v1/tests")
+@CrossOrigin(origins = {"http://localhost:3000, https://marketplace.johros.dev"}, allowCredentials = "true")
+@Controller
+public class TestingController {
+
+  private final UserService userService;
+
+  public TestingController(UserService userService) {
+    this.userService = userService;
+  }
+
+  @GetMapping("/username")
+  public ResponseEntity<?> getUsername(Principal principal) {
+    Account authenticatedUser = userService.getAccountOrException(principal.getName());
+    String json = "{\"username\": \"%s\"}".formatted(authenticatedUser.getUsername());
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return new ResponseEntity<>(json, headers, HttpStatus.OK);
+  }
+
+}

--- a/src/test/java/org/example/marketplacebackend/AuthTests.java
+++ b/src/test/java/org/example/marketplacebackend/AuthTests.java
@@ -1,0 +1,93 @@
+package org.example.marketplacebackend;
+
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class AuthTests {
+
+  @LocalServerPort
+  private int port;
+
+  @Container
+  private static final PostgreSQLContainer<?> DB = new PostgreSQLContainer<>(
+      "postgres:16-alpine"
+  )
+      .withInitScript("schema.sql");
+
+  @DynamicPropertySource
+  private static void configureProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", DB::getJdbcUrl);
+    registry.add("spring.datasource.username", DB::getUsername);
+    registry.add("spring.datasource.password", DB::getPassword);
+  }
+
+  private final TestRestTemplate restTemplate = new TestRestTemplate();
+
+  @Sql(executionPhase = ExecutionPhase.BEFORE_TEST_METHOD, statements = "INSERT INTO account (first_name, last_name, date_of_birth, email, password, username) VALUES ('John','Doe','2024-04-20','john@example.org','$2a$10$Fl73LSgJaTUaSfKvbjhOLO1s4eIXnWtJCq6g4gNIkU9BNtqETE4bG','johndoe')")
+  @Sql(executionPhase = ExecutionPhase.AFTER_TEST_METHOD, statements = "DELETE FROM account WHERE username = 'johndoe'")
+  @Test
+  public void testAuth() {
+    // set up authentication request
+    HttpHeaders requestHeaders = new HttpHeaders();
+    requestHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+    HttpEntity<String> request = new HttpEntity<>("username=johndoe&password=bruh", requestHeaders);
+
+    // perform authentication request
+    ResponseEntity<String> loginResponse = restTemplate.postForEntity(
+        "http://localhost:" + port + "/v1/accounts/login", request, String.class);
+    Assertions.assertEquals(HttpStatus.OK, loginResponse.getStatusCode(), "Authentication failed");
+
+    // grab cookies from request response
+    List<String> cookies = loginResponse.getHeaders().get(HttpHeaders.SET_COOKIE);
+    Assertions.assertNotNull(cookies, "No cookies were returned");
+
+    // try to find session cookie
+    String sessionCookie = null;
+    for (String cookie : cookies) {
+      if (cookie.startsWith("JSESSIONID=")) {
+        sessionCookie = cookie;
+        break;
+      }
+    }
+    Assertions.assertNotNull(sessionCookie, "No session cookie was returned");
+
+    // set up authenticated request
+    HttpHeaders authenticatedRequestHeaders = new HttpHeaders();
+    authenticatedRequestHeaders.add(HttpHeaders.COOKIE, sessionCookie);
+    HttpEntity<String> authenticatedRequest = new HttpEntity<>(authenticatedRequestHeaders);
+
+    // perform authenticated request to test endpoint
+    ResponseEntity<String> authenticatedResponse = restTemplate.exchange(
+        "http://localhost:" + port + "/v1/tests/username", HttpMethod.GET, authenticatedRequest,
+        String.class);
+    Assertions.assertEquals(HttpStatus.OK, authenticatedResponse.getStatusCode(), "Authentication failed");
+    Assertions.assertEquals("{\"username\": \"johndoe\"}", authenticatedResponse.getBody(), "Wrong username returned");
+
+    // perform logout request
+    ResponseEntity<String> logoutResponse = restTemplate.exchange(
+        "http://localhost:" + port + "/v1/accounts/logout", HttpMethod.POST, authenticatedRequest,
+        String.class);
+    Assertions.assertEquals(HttpStatus.OK, logoutResponse.getStatusCode(), "Logout failed");
+  }
+
+}


### PR DESCRIPTION
- Added logout endpoint at /v1/accounts/logout
- Configured application to return HTTP 401 when trying to access protected resources when unauthorized.
- Disabled default redirects which were issued on login/logout events. Now appropriate HTTP status codes are returned instead.
- Added auth test endpoint /v1/tests/username, which returns the username of the logged-in user. This can be used to test that auth is working correctly.
- Updated global CORS configuration to include the hostname of the hosted instance of the frontend (https://marketplace.johros.dev). This will also need to be added to all the controllers at a later time (don't want to cause merge conflicts).
- Added integration test which logs in, calls the auth test endpoint, and then logs out.