### PR TITLE
Image upload tweaks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ IMAGE_HOST_URL=
 
 # --- Optional environment variables ---
 
+# Uncomment the line below to customize maximum image upload limit per product (default limit=10 MB)
+#MAX_UPLOAD_SIZE_BYTES=10000000
+
 # Uncomment the line below to enable production mode settings:
 #SPRING_PROFILES_ACTIVE=production
 

--- a/src/main/java/org/example/marketplacebackend/service/ProductImageService.java
+++ b/src/main/java/org/example/marketplacebackend/service/ProductImageService.java
@@ -115,12 +115,19 @@ public class ProductImageService {
   }
 
   /**
-   * Deletes the given image to the database.
+   * Deletes the given image to the database and the local file system.
    *
    * @param image The image to be deleted.
    */
   public void deleteImage(ProductImage image) {
     productImageRepo.delete(image);
+    if (image.getImageUrl() == null || !image.getImageUrl().startsWith(IMAGE_HOST_URL)) {
+      throw new IllegalArgumentException();
+    }
+
+    String imageName = image.getImageUrl().split(IMAGE_HOST_URL + "/img/")[1];
+    File targetFile = new File(IMAGE_UPLOAD_DIRECTORY + "/" + imageName);
+    targetFile.delete();
   }
 
   @Transactional

--- a/src/main/java/org/example/marketplacebackend/service/ProductImageService.java
+++ b/src/main/java/org/example/marketplacebackend/service/ProductImageService.java
@@ -115,7 +115,7 @@ public class ProductImageService {
   }
 
   /**
-   * Deletes the given image to the database and the local file system.
+   * Deletes the given image from the database and the local file system.
    *
    * @param image The image to be deleted.
    */


### PR DESCRIPTION
- Increased image upload limit to 10 MB per product
- Added MAX_UPLOAD_SIZE_BYTES to .env.example
- Delete image files when calling the delete image method